### PR TITLE
fix: 심볼 변경 시 캔들 미렌더링 및 WebSocket Offline 버그 수정

### DIFF
--- a/src/hooks/useBinanceWebSocket.ts
+++ b/src/hooks/useBinanceWebSocket.ts
@@ -130,6 +130,9 @@ export const useBinanceWebSocket = ({
       return;
     }
 
+    // 심볼/인터벌 전환 시 이전 연결 상태 즉시 초기화
+    setIsConnected(false);
+
     wsClientRef.current = new BinanceWebSocketClient({
       symbol,
       interval,

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -43,6 +43,12 @@ export const useChartData = (): UseChartDataReturn => {
     if (latestCandle) updateCandle(latestCandle);
   }, [latestCandle, updateCandle]);
 
+  // 심볼/인터벌 변경 시 stale 데이터 즉시 제거
+  // → useChartInit이 새 데이터 도착 전에 initializeChart를 호출하는 것을 방지
+  useEffect(() => {
+    setRawData([]);
+  }, [symbol, interval, setRawData]);
+
   // Fetch data
   const fetchData = useCallback(async () => {
     try {

--- a/src/hooks/useChartInit.ts
+++ b/src/hooks/useChartInit.ts
@@ -1,7 +1,7 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect, useRef } from 'react';
 import { initializeChartAtom } from '../stores/atoms/actionAtoms';
-import { chartDimensionsAtom } from '../stores/atoms/chartConfigAtoms';
+import { chartDimensionsAtom, symbolAtom } from '../stores/atoms/chartConfigAtoms';
 import { rawDataAtom, visibleDataAtom } from '../stores/atoms/dataAtoms';
 import { chartDomainAtom, indexDomainAtom } from '../stores/atoms/domainAtoms';
 import { chartRangeAtom } from '../stores/atoms/rangeAtoms';
@@ -10,6 +10,7 @@ import { CandleData } from '../types';
 export const useChartInit = () => {
   const { width, height } = useAtomValue(chartDimensionsAtom);
   const chartData = useAtomValue(rawDataAtom);
+  const symbol = useAtomValue(symbolAtom);
   const domain = useAtomValue(chartDomainAtom);
   const range = useAtomValue(chartRangeAtom);
   const visibleData = useAtomValue(visibleDataAtom);
@@ -19,6 +20,7 @@ export const useChartInit = () => {
 
   const prevDataRef = useRef<CandleData[]>([]);
   const prevLengthRef = useRef(0);
+  const prevSymbolRef = useRef<string>('');
 
   useEffect(() => {
     if (chartData.length === 0) return;
@@ -26,13 +28,15 @@ export const useChartInit = () => {
     const prevData = prevDataRef.current;
     const sizeChanged = range.width !== width || range.height !== height;
 
-    // 데이터셋이 통째로 교체됐는지 판별: 첫 캔들 timestamp가 다르면 새 데이터
-    const isDataReplaced =
-      prevData.length === 0 || chartData[0]?.timestamp !== prevData[0]?.timestamp;
+    // 심볼이 바뀌었거나 최초 로드인 경우 전체 재초기화
+    // (timestamp 비교는 BTC/ETH 같은 동일 interval 심볼 간에 첫 캔들 timestamp가
+    //  동일할 수 있어 신뢰할 수 없음)
+    const isNewSymbol = prevData.length === 0 || symbol !== prevSymbolRef.current;
 
-    if (isDataReplaced || sizeChanged) {
-      // 전체 재초기화: 새 데이터셋 or 컨테이너 리사이즈
+    if (isNewSymbol || sizeChanged) {
+      // 전체 재초기화: 새 심볼 데이터셋 or 컨테이너 리사이즈
       initializeChart({ width, height });
+      prevSymbolRef.current = symbol;
     } else if (chartData.length > prevLengthRef.current) {
       // WebSocket: 새 캔들 추가 → index domain 시프트
       const indexShift = chartData.length - prevLengthRef.current;
@@ -44,7 +48,7 @@ export const useChartInit = () => {
 
     prevDataRef.current = chartData;
     prevLengthRef.current = chartData.length;
-  }, [chartData, width, height, initializeChart, setIndexDomain, range.width, range.height]);
+  }, [chartData, symbol, width, height, initializeChart, setIndexDomain, range.width, range.height]);
 
   return { domain, range, visibleData };
 };

--- a/src/services/websocket/binanceWebSocket.ts
+++ b/src/services/websocket/binanceWebSocket.ts
@@ -49,6 +49,7 @@ export class BinanceWebSocketClient {
     };
 
     this.ws.onmessage = (event: MessageEvent) => {
+      if (this.isIntentionallyClosed) return;
       try {
         const data: BinanceKlineWebSocketData = JSON.parse(event.data);
         this.config.onMessage?.(data);
@@ -58,18 +59,20 @@ export class BinanceWebSocketClient {
     };
 
     this.ws.onerror = (error: Event) => {
+      if (this.isIntentionallyClosed) return;
       console.error('WebSocket error:', error);
       this.handleError(new Error('WebSocket error occurred'));
     };
 
     this.ws.onclose = (event: CloseEvent) => {
+      // 의도적으로 닫은 경우 콜백·재연결 모두 생략
+      // (심볼 전환 시 구 연결의 onclose가 새 연결 이후에 도착해
+      //  isConnected를 false로 덮어쓰는 race condition 방지)
+      if (this.isIntentionallyClosed) return;
+
       console.log('WebSocket disconnected:', event.code, event.reason);
       this.config.onDisconnect?.();
-
-      // 의도적으로 닫은 경우가 아니면 재연결 시도
-      if (!this.isIntentionallyClosed) {
-        this.attemptReconnect();
-      }
+      this.attemptReconnect();
     };
   }
 


### PR DESCRIPTION
## Summary

- **캔들 미렌더링 버그**: BTC 외 다른 심볼(ETH, BNB 등)로 전환 시 캔들이 표시되지 않던 문제 수정
  - 원인: `useChartInit`에서 심볼 변경 감지를 `chartData[0].timestamp` 비교로 했는데, Binance는 모든 심볼 캔들을 UTC 시간 경계에 정렬하므로 동일 interval의 BTC/ETH 첫 캔들 timestamp가 동일함
  - 수정: `prevSymbolRef`로 symbol 자체를 추적하여 심볼 변경 시 차트를 재초기화

- **WebSocket Offline 버그**: 심볼 변경을 반복하면 Live 상태가 Offline으로 바뀌는 문제 수정
  - 원인: 구 연결의 `onclose` 이벤트가 비동기적으로 늦게 도착해 새 연결의 `isConnected=true`를 `false`로 덮어쓰는 race condition
  - 수정: `isIntentionallyClosed=true`일 때 `onmessage`, `onerror`, `onclose` 콜백 모두 조기 반환. 또한 새 연결 생성 전 `setIsConnected(false)` 명시적 호출로 전환 중 상태 정확히 표시

## Test Plan
- [x] BTCUSDT → ETHUSDT 전환 시 ETH 캔들 정상 렌더링 확인
- [x] 여러 심볼 간 빠르게 전환 시 Live 상태 유지 확인
- [x] 단일 심볼에서 WebSocket 연결/재연결 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)